### PR TITLE
Build qtable na fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Description: A high-level interface for creating and exporting summary tables to
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Collate:
   as_base_r.R
   xlr_table.R

--- a/R/build_question_block_table.R
+++ b/R/build_question_block_table.R
@@ -190,10 +190,10 @@ build_qtable <- function(
   # now pivot longer so we can put everything in the one table
   long_data <-
     x_selected |>
-    # remove the NA"s if we need too
-    remove_NA_opt(use_NA) |>
     pivot_longer(cols = {{block_cols}},
-                 names_to = "Question Block")
+                 names_to = "Question Block") |>
+  # remove the NA"s if we need too
+  remove_NA_opt(use_NA)
 
   # now we have the long data we need calculate the summary table
   # and pivot it wider

--- a/tests/testthat/test-build_question_block_table.R
+++ b/tests/testthat/test-build_question_block_table.R
@@ -274,4 +274,38 @@ test_that("use_questions pulls out the column names (the questions) as expected"
   })
 
 
+test_that("build_qtable removes only NA responses in a question block, retaining valid responses", {
+  # Create a sample data frame for a question block (Q1 with sub-questions Q1_a, Q1_b, Q1_c)
+  test_data <- data.frame(
+    ID = 1:5,  # Respondent IDs
+    Q1_a = c("Yes", "No", NA, "Yes", "No"),  # Mix of valid and NA responses
+    Q1_b = c("No", NA, "Yes", "Yes", "No"),
+    Q1_c = c(NA, "Yes", "No", "No", NA)
+  )
 
+  # Run build_qtable on the question block (assuming it processes columns Q1_a, Q1_b, Q1_c)
+  result <- build_qtable(test_data, all_of(c("Q1_a", "Q1_b", "Q1_c")))
+
+  # Expected behavior:
+  # - Respondent 1: Q1_a = Yes, Q1_b = No, Q1_c = NA (should contribute to Q1_a and Q1_b counts)
+  # - Respondent 2: Q1_a = No, Q1_b = NA, Q1_c = Yes (should contribute to Q1_a and Q1_c counts)
+  # - Respondent 3: Q1_a = NA, Q1_b = Yes, Q1_c = No (should contribute to Q1_b and Q1_c counts)
+  # - Respondent 4: Q1_a = Yes, Q1_b = Yes, Q1_c = No (should contribute to all)
+  # - Respondent 5: Q1_a = No, Q1_b = No, Q1_c = NA (should contribute to Q1_a and Q1_b counts)
+  # - Total N = 5 (all respondents have at least one non-NA response)
+
+  # Expected frequency table (example structure, adjust based on build_qtable output)
+  expected <- tibble::tribble(
+    ~`Question Block`, ~value, ~N, ~Percent,
+    "Q1_a", "No", 2L, .50,
+    "Q1_a", "Yes", 2L, .50,
+    "Q1_b", "No", 2L, .50,
+    "Q1_b", "Yes", 2L, .50,
+    "Q1_c", "No", 2L, 2/3,
+    "Q1_c", "Yes", 1L, 1/3
+  ) |>
+    xlr_table() |>
+    mutate(Percent = xlr_percent(Percent))
+  # Check that the output matches expected frequencies
+  expect_equal(result, expected,info = "The xlr tables match")
+})

--- a/tests/testthat/test-build_question_block_table.R
+++ b/tests/testthat/test-build_question_block_table.R
@@ -274,7 +274,7 @@ test_that("use_questions pulls out the column names (the questions) as expected"
   })
 
 
-test_that("build_qtable removes only NA responses in a question block, retaining valid responses", {
+test_that("build_qtable removes NA for each question, instead of the entire observation if it contains a NA ", {
   # Create a sample data frame for a question block (Q1 with sub-questions Q1_a, Q1_b, Q1_c)
   test_data <- data.frame(
     ID = 1:5,  # Respondent IDs


### PR DESCRIPTION
Fix an issue where an entire observation was removed if it contained one NA response to a question in `build_qtable` instead of removing just the NA response from the question. Added associated tests. Updated the roxygen.